### PR TITLE
Force newer GLFW bindings in stack-config.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -10,4 +10,6 @@ extra-deps:
 - lambdacube-gl-0.5.2.4
 - wavefront-0.7.1
 - MonadRandom-0.5.1
+- GLFW-b-1.4.8.4
+- bindings-GLFW-3.2.1.1
 resolver: lts-6.25


### PR DESCRIPTION
To make workshop examples run on my Fedora 27 Lenovo T540p Intel/NVIDIA hybrid.